### PR TITLE
Update to support midpoint 3.6.1-SNAPSHOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .project
 
 /target
+/.idea
+/midpoint-jaspersoft-studio-integration.iml

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 	<version>1.0.0-SNAPSHOT</version>
 	<properties>
 		<project.source.version>1.7</project.source.version>
+        <midpoint.version>3.6.1-SNAPSHOT</midpoint.version>
 	</properties>
 
 
@@ -30,7 +31,7 @@
 			<plugin>
 				<groupId>org.apache.portals.jetspeed-2</groupId>
 				<artifactId>jetspeed-unpack-maven-plugin</artifactId>
-				<version>2.3.0</version>
+				<version>2.3.1</version>
 				<executions>
 					<execution>
 						<id>unpack-messages</id>
@@ -56,11 +57,12 @@
 					<dependency>
 						<groupId>com.evolveum.midpoint.gui</groupId>
 						<artifactId>admin-gui</artifactId>
-						<version>3.3-SNAPSHOT</version>
+						<version>${midpoint.version}</version>
 						<type>war</type>
 					</dependency>
 				</dependencies>
 			</plugin>
+
 <!-- 		<plugin> -->
 <!--                 <groupId>org.apache.maven.plugins</groupId> -->
 <!--                 <artifactId>maven-dependency-plugin</artifactId> -->
@@ -89,7 +91,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.6.2</version>
 				<configuration>
 					<source>1.7</source>
 					<target>1.7</target>
@@ -156,10 +158,15 @@
 	</build>
 
 	<dependencies>
+        <dependency>
+            <groupId>org.eclipse.core</groupId>
+            <artifactId>runtime</artifactId>
+            <version>3.10.0-v20140318-2214</version>
+        </dependency>
 		<dependency>
 			<groupId>com.evolveum.midpoint.model</groupId>
 			<artifactId>model-client</artifactId>
-			<version>3.3-SNAPSHOT</version>
+			<version>${midpoint.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
@@ -224,7 +231,7 @@
 		<dependency>
 			<groupId>com.evolveum.midpoint.model</groupId>
 			<artifactId>report-api</artifactId>
-			<version>3.3-SNAPSHOT</version>
+			<version>${midpoint.version}</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>prism</artifactId>

--- a/src/main/java/com/evolveum/midpoint/jaspersoft/studio/integration/MidPointRemoteQueryExecutor.java
+++ b/src/main/java/com/evolveum/midpoint/jaspersoft/studio/integration/MidPointRemoteQueryExecutor.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import javax.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 
+import com.evolveum.midpoint.xml.ns._public.common.common_3.GetOperationOptionsType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.SelectorQualifiedGetOptionType;
 import net.sf.jasperreports.engine.JRDataSource;
 import net.sf.jasperreports.engine.JRDataset;
 import net.sf.jasperreports.engine.JRException;
@@ -29,23 +31,20 @@ import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource;
 import net.sf.jasperreports.engine.query.JRAbstractQueryExecuter;
 
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.core.internal.dtree.ObjectNotFoundException;
+//import org.eclipse.core.internal.dtree.ObjectNotFoundException;
 
 import com.evolveum.midpoint.model.client.ModelClientUtil;
 import com.evolveum.midpoint.prism.xml.XsdTypeMapper;
 import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.util.logging.Trace;
 import com.evolveum.midpoint.util.logging.TraceManager;
-import com.evolveum.midpoint.xml.ns._public.common.api_types_3.GetOperationOptionsType;
 import com.evolveum.midpoint.xml.ns._public.common.api_types_3.ObjectListType;
-import com.evolveum.midpoint.xml.ns._public.common.api_types_3.SelectorQualifiedGetOptionType;
-import com.evolveum.midpoint.xml.ns._public.common.api_types_3.SelectorQualifiedGetOptionsType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.SelectorQualifiedGetOptionsType;
 import com.evolveum.midpoint.xml.ns._public.common.audit_3.AuditEventRecordListType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ReportParameterType;
 import com.evolveum.midpoint.xml.ns._public.report.report_3.RemoteReportParameterType;
 import com.evolveum.midpoint.xml.ns._public.report.report_3.RemoteReportParametersType;
 import com.evolveum.midpoint.xml.ns._public.report.report_3.ReportPortType;
-//import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.prism.xml.ns._public.types_3.RawType;
 
 public class MidPointRemoteQueryExecutor extends JRAbstractQueryExecuter {
@@ -163,6 +162,7 @@ public class MidPointRemoteQueryExecutor extends JRAbstractQueryExecuter {
 
 			if (queryString != null) {
 				results = reportPort.processReport(queryString, converToReportParameterType(false), createRawOption());
+
 			} else {
 				if (script.contains("AuditEventRecord")) {
 					AuditEventRecordListType auditResults = reportPort.evaluateAuditScript(script, converToReportParameterType(true));
@@ -174,7 +174,7 @@ public class MidPointRemoteQueryExecutor extends JRAbstractQueryExecuter {
 					results = reportPort.evaluateScript(script, reportParamters);
 				}
 			}
-		} catch (SchemaException | ObjectNotFoundException e) {
+		} catch (SchemaException e) {
 			throw new JRException(e);
 		}
 		return new MidPointRemoteDataSource(results.getObject());
@@ -182,7 +182,7 @@ public class MidPointRemoteQueryExecutor extends JRAbstractQueryExecuter {
 	}
 	
 	private SelectorQualifiedGetOptionsType createRawOption(){
-		SelectorQualifiedGetOptionsType options = new SelectorQualifiedGetOptionsType();
+        SelectorQualifiedGetOptionsType options = new SelectorQualifiedGetOptionsType();
 		SelectorQualifiedGetOptionType option = new SelectorQualifiedGetOptionType();
 		GetOperationOptionsType getOptions = new GetOperationOptionsType();
 		getOptions.setRaw(Boolean.TRUE);


### PR DESCRIPTION
This may need the attention of someone more familiar with Jasper and the midpoint soap api. It does compile and mostly run against midpoint 3.6, but there are soap fault issues with a lot of queries still.